### PR TITLE
Added test provider to testnet registry.json

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -2,5 +2,9 @@
   {
     "name": "SwapMarket.online",
     "endpoint": "https://tdex.swapmarket.online"
+  },
+  {
+    "name": "Test_Provider",
+    "endpoint": "http://172.161.100.170:9946"
   }
 ]


### PR DESCRIPTION
---
name: Provider Request
about: Request a provider addition to the registry
title: Added test provider to testnet registry
labels: provider request
assignees: ''
---

**Please read the following instructions carefully.**

Test your provider is reachable making the following HTTP request and make sure the response code is `200`.

**Replace endpoint with your actual public reachable endpoint, comprhensive of http or https.**

```sh
curl -w "%{http_code}" -o /dev/null -s -X POST <endpoint>/v1/markets \
  --header 'Content-Type: application/json' \
  --data-raw '{}'
```

**For Tor hidden services, run a Tor Browser and add the `--socks5-hostname` flag to the command:**

```sh
curl -w "%{http_code}" -o /dev/null -s -X POST <endpoint>/v1/markets \
  --header 'Content-Type: application/json' \
  --data-raw '{}' \
  --socks5-hostname localhost:9150
```

**Please read and accept the following statements carefully.**

- [✓ ] I understand that provider listing is not required to accept trades on the tdex network.
- [ ✓] I understand that filing an issue or adding liquidity does not guarantee addition to the tdex public registry.
- [ ✓] I will not ping the Telegram group or contact any developer about this listing request.
- [ ] I have tested the `/v1/markets` endpoint and can confirm that it is returning valid data.
     -> Tested against /v2/markets